### PR TITLE
Remove storage retrieval validation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,9 +16,9 @@ variables:
 - group: hwsc-dev-container-vars
 
 steps:
-  - task: DownloadSecureFile@1
-    inputs:
-      secureFile: hwscdevcontainer_pw.txt
+- task: DownloadSecureFile@1
+  inputs:
+    secureFile: hwscdevcontainer_pw.txt
 - script: |
     cat $(Agent.TempDirectory)/hwscdevcontainer_pw.txt | docker login -u "$(hwscDevContainerUser)" --email="$(hwscDevContainerUserEmail)" --password-stdin
     docker build --no-cache -f Dockerfile -t hwsc/$(hwscDevImageName):$(build.buildId) .

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,18 +16,14 @@ variables:
 - group: hwsc-dev-container-vars
 
 steps:
-- task: DownloadSecureFile@1
-  inputs:
-    secureFile: hwscdevcontainer_pw.txt
 - script: |
-    cat $(Agent.TempDirectory)/hwscdevcontainer_pw.txt | docker login -u "$(hwscDevContainerUser)" --password-stdin hwscdevcontainer.azurecr.io
-    docker build --no-cache -f Dockerfile -t $(hwscDevDockerId)/$(hwscDevImageName):$(build.buildId) .
+    docker build --no-cache -f Dockerfile -t hwsc/$(hwscDevImageName):$(build.buildId) .
   
   displayName: 'Build Docker Image'
   
 - script: |
-    docker tag $(hwscDevImageName) $(hwscDevDockerId)/$(hwscDevImageName):$(build.buildId)
-    docker push $(hwscDevDockerId)/$(hwscDevImageName):$(build.buildId)
+    docker tag $(hwscDevImageName) hwsc/$(hwscDevImageName):$(build.buildId)
+    docker push hwsc/$(hwscDevImageName):$(build.buildId)
   
   displayName: 'Push Docker Image'
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ steps:
   displayName: 'Build Docker Image'
   
 - script: |
-    docker tag hwsc/  $(hwscDevImageName) hwsc/$(hwscDevImageName):$(build.buildId)
+    docker tag $(hwscDevImageName) hwsc/$(hwscDevImageName):$(build.buildId)
     docker push hwsc/$(hwscDevImageName):$(build.buildId)
   
   displayName: 'Push Docker Image'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,13 +16,17 @@ variables:
 - group: hwsc-dev-container-vars
 
 steps:
+  - task: DownloadSecureFile@1
+    inputs:
+      secureFile: hwscdevcontainer_pw.txt
 - script: |
+    cat $(Agent.TempDirectory)/hwscdevcontainer_pw.txt | docker login -u "$(hwscDevContainerUser)" --email="$(hwscDevContainerUserEmail)" --password-stdin
     docker build --no-cache -f Dockerfile -t hwsc/$(hwscDevImageName):$(build.buildId) .
   
   displayName: 'Build Docker Image'
   
 - script: |
-    docker tag $(hwscDevImageName) hwsc/$(hwscDevImageName):$(build.buildId)
+    docker tag hwsc/  $(hwscDevImageName) hwsc/$(hwscDevImageName):$(build.buildId)
     docker push hwsc/$(hwscDevImageName):$(build.buildId)
   
   displayName: 'Push Docker Image'

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -643,7 +643,7 @@ func TestAddFileMetadata(t *testing.T) {
 				Media: pb.FileType_IMAGE,
 			},
 		}, available,
-			"OK", false, 9,
+			"OK", false, 3,
 		},
 		{&pb.DocumentRequest{
 			FileMetadataParameters: &pb.FileMetadataTransaction{
@@ -653,7 +653,7 @@ func TestAddFileMetadata(t *testing.T) {
 				Media: pb.FileType_VIDEO,
 			},
 		}, available,
-			"OK", false, 10,
+			"OK", false, 3,
 		},
 		{&pb.DocumentRequest{
 			FileMetadataParameters: &pb.FileMetadataTransaction{
@@ -663,7 +663,7 @@ func TestAddFileMetadata(t *testing.T) {
 				Media: pb.FileType_AUDIO,
 			},
 		}, available,
-			"OK", false, 11,
+			"OK", false, 3,
 		},
 		{&pb.DocumentRequest{
 			FileMetadataParameters: &pb.FileMetadataTransaction{
@@ -673,7 +673,7 @@ func TestAddFileMetadata(t *testing.T) {
 				Media: pb.FileType_FILE,
 			},
 		}, available,
-			"OK", false, 12,
+			"OK", false, 3,
 		},
 	}
 
@@ -683,9 +683,7 @@ func TestAddFileMetadata(t *testing.T) {
 		res, err := s.AddFileMetadata(context.TODO(), c.req)
 		if !c.isExpErr {
 			assert.Nil(t, err)
-			totalFiles := len(res.GetData().GetAudioUrlsMap()) + len(res.GetData().GetImageUrlsMap()) +
-				len(res.GetData().GetVideoUrlsMap()) + len(res.GetData().GetFileUrlsMap())
-			assert.Equal(t, c.expNumDocs, totalFiles)
+			assert.NotNil(t, res)
 			switch c.req.FileMetadataParameters.GetMedia() {
 			case pb.FileType_FILE:
 				for k, v := range res.Data.GetFileUrlsMap() {
@@ -693,11 +691,17 @@ func TestAddFileMetadata(t *testing.T) {
 						tempFileFUID = k
 					}
 				}
+				if !assert.Equal(t, c.expNumDocs, len(res.GetData().GetFileUrlsMap())) {
+					assert.Fail(t, c.req.FileMetadataParameters.GetUrl())
+				}
 			case pb.FileType_AUDIO:
 				for k, v := range res.Data.GetAudioUrlsMap() {
 					if v == c.req.FileMetadataParameters.GetUrl() {
 						tempAudioFUID = k
 					}
+				}
+				if !assert.Equal(t, c.expNumDocs, len(res.GetData().GetAudioUrlsMap())) {
+					assert.Fail(t, c.req.FileMetadataParameters.GetUrl())
 				}
 			case pb.FileType_IMAGE:
 				for k, v := range res.Data.GetImageUrlsMap() {
@@ -705,11 +709,17 @@ func TestAddFileMetadata(t *testing.T) {
 						tempImageFUID = k
 					}
 				}
+				if !assert.Equal(t, c.expNumDocs, len(res.GetData().GetImageUrlsMap())) {
+					assert.Fail(t, c.req.FileMetadataParameters.GetUrl())
+				}
 			case pb.FileType_VIDEO:
 				for k, v := range res.Data.GetVideoUrlsMap() {
 					if v == c.req.FileMetadataParameters.GetUrl() {
 						tempVideoFUID = k
 					}
+				}
+				if !assert.Equal(t, c.expNumDocs, len(res.GetData().GetVideoUrlsMap())) {
+					assert.Fail(t, c.req.FileMetadataParameters.GetUrl())
 				}
 			}
 		} else {
@@ -803,7 +813,7 @@ func TestDeleteFileMetadata(t *testing.T) {
 				Fuid:  tempImageFUID,
 			},
 		}, available,
-			"OK", false, 11,
+			"OK", false, 2,
 		},
 		{&pb.DocumentRequest{
 			FileMetadataParameters: &pb.FileMetadataTransaction{
@@ -813,7 +823,7 @@ func TestDeleteFileMetadata(t *testing.T) {
 				Fuid:  tempVideoFUID,
 			},
 		}, available,
-			"OK", false, 10,
+			"OK", false, 2,
 		},
 		{&pb.DocumentRequest{
 			FileMetadataParameters: &pb.FileMetadataTransaction{
@@ -823,7 +833,7 @@ func TestDeleteFileMetadata(t *testing.T) {
 				Fuid:  tempAudioFUID,
 			},
 		}, available,
-			"OK", false, 9,
+			"OK", false, 2,
 		},
 		{&pb.DocumentRequest{
 			FileMetadataParameters: &pb.FileMetadataTransaction{
@@ -833,7 +843,7 @@ func TestDeleteFileMetadata(t *testing.T) {
 				Fuid:  tempFileFUID,
 			},
 		}, available,
-			"OK", false, 8,
+			"OK", false, 2,
 		},
 	}
 
@@ -843,9 +853,25 @@ func TestDeleteFileMetadata(t *testing.T) {
 		res, err := s.DeleteFileMetadata(context.TODO(), c.req)
 		if !c.isExpErr {
 			assert.Nil(t, err)
-			totalFiles := len(res.GetData().GetAudioUrlsMap()) + len(res.GetData().GetImageUrlsMap()) +
-				len(res.GetData().GetVideoUrlsMap()) + len(res.GetData().GetFileUrlsMap())
-			assert.Equal(t, c.expNumDocs, totalFiles)
+			assert.NotNil(t, res)
+			switch c.req.FileMetadataParameters.GetMedia() {
+			case pb.FileType_FILE:
+				if !assert.Equal(t, c.expNumDocs, len(res.GetData().GetFileUrlsMap())) {
+					assert.Fail(t, c.req.FileMetadataParameters.GetFuid())
+				}
+			case pb.FileType_AUDIO:
+				if !assert.Equal(t, c.expNumDocs, len(res.GetData().GetAudioUrlsMap())) {
+					assert.Fail(t, c.req.FileMetadataParameters.GetFuid())
+				}
+			case pb.FileType_IMAGE:
+				if !assert.Equal(t, c.expNumDocs, len(res.GetData().GetImageUrlsMap())) {
+					assert.Fail(t, c.req.FileMetadataParameters.GetFuid())
+				}
+			case pb.FileType_VIDEO:
+				if !assert.Equal(t, c.expNumDocs, len(res.GetData().GetVideoUrlsMap())) {
+					assert.Fail(t, c.req.FileMetadataParameters.GetFuid())
+				}
+			}
 		} else {
 			assert.Equal(t, c.expMsg, err.Error())
 			assert.EqualError(t, err, c.expMsg)

--- a/service/unit_test.sh
+++ b/service/unit_test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-go test -coverprofile=coverage.out
+go test -coverprofile=coverage.out -failfast
 
 # Opens a summary of code coverage in the browser
 go tool cover -html=coverage.out

--- a/service/utility.go
+++ b/service/utility.go
@@ -712,11 +712,10 @@ func ValidateURL(addr string) error {
 	if _, err := url.ParseRequestURI(addr); err != nil {
 		return errUnreachableURI
 	}
-
 	resp, err := http.Get(addr)
 	if err != nil || resp.StatusCode >= 400 {
 		return errUnreachableURI
 	}
-
+	_ = resp.Body.Close()
 	return nil
 }


### PR DESCRIPTION
I removed validation after storage retrieval due to performance issue with the following utility function:
```
func ValidateURL(addr string) error {
	if _, err := url.ParseRequestURI(addr); err != nil {
		return errUnreachableURI
	}
	resp, err := http.Get(addr)
	if err != nil || resp.StatusCode >= 400 {
		return errUnreachableURI
	}
	_ = resp.Body.Close()
	return nil
}
```

`resp, err := http.Get(addr)` downloads the media files thus causing the extreme slowness.

We only validate on Create and Update